### PR TITLE
Added jfrog artifacotry for the new RPM builds to be published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,19 +42,23 @@
             <name>Rackspace Research Releases</name>
             <url>https://maven.research.rackspacecloud.com/content/repositories/releases</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <name>IAD Artifacts-releases</name>
+            <url>https://artifacts.rackspace.net:443/artifactory/cloudfeeds-maven-local</url>
+        </repository>
     </repositories>
 
     <distributionManagement>
         <repository>
-            <id>releases.maven.research.rackspace.com</id>
-            <name>Rackspace Research Releases</name>
-            <url>https://maven.research.rackspacecloud.com/content/repositories/releases</url>
+            <id>central</id>
+            <name>IAD Artifacts-releases</name>
+            <url>https://artifacts.rackspace.net:443/artifactory/cloudfeeds-maven-local</url>
         </repository>
-
         <snapshotRepository>
-            <id>snapshots.maven.research.rackspace.com</id>
-            <name>Rackspace Research Snapshots</name>
-            <url>https://maven.research.rackspacecloud.com/content/repositories/snapshots</url>
+            <id>snapshots</id>
+            <name>IAD Artifacts-snapshots</name>
+            <url>https://artifacts.rackspace.net:443/artifactory/cloudfeeds-maven-local</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -76,7 +80,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Also fixed the security vulnerability issue for commons-collections:commons-collections by updating to latest version 3.2.2

All the published build can be viewed here for frog artifactory.
https://artifacts.rackspace.net/artifactory/webapp/#/artifacts/browse/tree/General/cloudfeeds-maven-local