### PR TITLE
Cf 2751 containerize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ target
 /server/catalog.xml
 /test-suite/catalog.xml
 /ah-war/nbactions.xml
+
+#License files
+*.lic

--- a/configuration/common/client-auth-n.cfg.xml
+++ b/configuration/common/client-auth-n.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<client-auth xmlns="http://docs.openrepose.org/repose/client-auth/v1.0">
+
+    <delegating quality="0.9"/>
+    <openstack-auth  tenanted="false" group-cache-timeout="60000" connectionPoolId="client-auth-pool" token-cache-timeout="600000"  send-all-tenant-ids="true" xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+        <identity-service username="atomhopper" password="JZHW45davGruWApx" uri="https://staging.identity-internal.api.rackspacecloud.com/v2.0" />
+        <ignore-tenant-roles>
+              <role>identity:admin</role>
+        </ignore-tenant-roles>
+    </openstack-auth>
+
+
+</client-auth>

--- a/configuration/common/container.cfg.xml
+++ b/configuration/common/container.cfg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
+<repose-container xmlns="http://docs.openrepose.org/repose/container/v2.0">
+    <deployment-config
+        content-body-read-limit="2097152"
+        >
+
+        <deployment-directory auto-clean="true">/var/repose</deployment-directory>
+
+        <artifact-directory check-interval="60000">/usr/share/repose/filters</artifact-directory>
+
+        <logging-configuration href="file:///etc/repose/log4j2.xml"/>
+
+    </deployment-config>
+</repose-container>
+

--- a/configuration/common/fail-404.wadl
+++ b/configuration/common/fail-404.wadl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<application
+        xmlns="http://wadl.dev.java.net/2009/02"
+        >
+
+    <grammars>
+    </grammars>
+    <resources base="http://localhost:8080/">
+        <resource path="no-resource">
+        </resource>
+    </resources>
+</application>

--- a/configuration/common/feedscatalog-translation.cfg.xml
+++ b/configuration/common/feedscatalog-translation.cfg.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://wiki.openrepose.org/display/REPOSE/Translation -->
+<translation xmlns="http://docs.rackspacecloud.com/repose/translation/v1.0"
+    xsl-engine="SaxonEE" >
+    <request-translations>
+
+    </request-translations>
+    <response-translations>
+  
+        <response-translation 
+            content-type="application/xml" 
+            accept="*/*"
+            translated-content-type="application/xml">
+            <style-sheets>
+    
+                <style id="feedscatalog-resolve" href="feedscatalog/feedscatalog-resolve.xsl" />
+    
+            </style-sheets>
+        </response-translation>
+  
+    </response-translations>
+
+</translation>

--- a/configuration/common/header-id-mapping.cfg.xml
+++ b/configuration/common/header-id-mapping.cfg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<header-id-mapping xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+                   xmlns='http://docs.openrepose.org/repose/header-id-mapping/v1.0'
+                   xsi:schemaLocation='http://docs.openrepose.org/repose/header-id-mapping/v1.0 ../config/header-id-mapping-configuration.xsd'>
+
+    <source-headers>
+        <header id="header-mapping-1" user-header="X-RAX-USER" group-header="X-RAX-GROUPS" quality="0.2"/>
+    </source-headers>
+
+</header-id-mapping>

--- a/configuration/common/header-identity.cfg.xml
+++ b/configuration/common/header-identity.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/Header+Identity -->
+<header-identity xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+                 xmlns='http://docs.openrepose.org/repose/header-identity/v1.0'
+                 xsi:schemaLocation='http://docs.openrepose.org/repose/header-identity/v1.0 ../config/header-identity-configuration.xsd'>
+
+    <source-headers>
+        <header id="X-Auth-Token" quality=".95"/>
+        <header id="X-Forwarded-For" quality="0.5"/>
+    </source-headers>
+
+</header-identity>

--- a/configuration/common/header-normalization-karate.cfg.xml
+++ b/configuration/common/header-normalization-karate.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<header-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://docs.openrepose.org/repose/header-normalization/v1.0"
+    xsi:schemaLocation="http://undefined/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd">
+    <header-filters>
+        <target>
+            <blacklist id="ReposeHeaders">
+                <header id="X-PP-User"/>
+                <header id="X-User-Name"/>
+                <header id="X-Catalog"/>
+            </blacklist>
+    </target>
+    </header-filters>
+</header-normalization>

--- a/configuration/common/header-normalization.cfg.xml
+++ b/configuration/common/header-normalization.cfg.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<header-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://docs.openrepose.org/repose/header-normalization/v1.0"
+    xsi:schemaLocation="http://undefined/repose/header-normalization/v1.0 ../config/header-normalization-configuration.xsd">
+    <header-filters>
+        <target>
+            <blacklist id="ReposeHeaders">
+                <header id="X-PP-User"/>
+                <header id="X-PP-Groups"/>
+                <header id="X-Authorization"/>
+                <header id="X-Identity-Status"/>
+                <header id="X-User-Name"/>
+                <header id="X-User-Id"/>
+                <header id="X-Tenant-Name"/>
+                <header id="X-Tenant-Id"/>
+                <header id="X-Roles"/>
+                <header id="X-Impersonator-Id"/>
+                <header id="X-Impersonator-Name"/>
+            </blacklist>
+    </target>
+    </header-filters>
+</header-normalization>

--- a/configuration/common/highly-efficient-record-processor.cfg.xml
+++ b/configuration/common/highly-efficient-record-processor.cfg.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<highly-efficient-record-processor xmlns="http://docs.openrepose.org/repose/highly-efficient-record-processor/v1.0"
+                                   pre-filter-logger-name="org.openrepose.herp.pre.filter"
+                                   post-filter-logger-name="org.openrepose.herp.post.filter"
+                                   service-code="cloudFeeds" region="ORD" data-center="ORD1">
+    <template crush="false">
+    <![CDATA[
+        <cadf:event xmlns:cadf="http://schemas.dmtf.org/cloud/audit/1.0/event"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation='http://schemas.dmtf.org/cloud/audit/1.0/event user-access-cadf.xsd'
+                    xmlns:ua="http://feeds.api.rackspacecloud.com/cadf/user-access-event"
+                    id="{{guid}}"
+                    eventType="activity"
+                    typeURI="http://schemas.dmtf.org/cloud/audit/1.0/event"
+                    eventTime="{{cadfTimestamp timestamp}}"
+                    action="{{cadfMethod requestMethod}}"
+                    outcome="{{cadfOutcome responseCode}}">
+            <cadf:initiator id="{{#if impersonatorName}}impersonatorName{{else}}{{userName}}{{/if}}"
+                            typeURI="network/node" name="{{#if impersonatorName}}impersonatorName{{else}}{{userName}}{{/if}}">
+                <cadf:host address="{{requestorIp}}" agent="{{userAgent}}" />
+            </cadf:initiator>
+            <cadf:target id="{{targetHost}}" typeURI="service" name="{{serviceCode}}" >
+                <cadf:host address="{{targetHost}}" />
+            </cadf:target>
+            <cadf:attachments>
+                <cadf:attachment name="auditData" contentType="ua:auditData">
+                    <cadf:content>
+                        <ua:auditData version="1">
+                            <ua:region>{{region}}</ua:region>
+                            <ua:dataCenter>{{dataCenter}}</ua:dataCenter>
+                            <ua:methodLabel>{{methodLabel}}</ua:methodLabel>
+                            <ua:requestURL>{{requestURL}}</ua:requestURL>
+                            <ua:queryString>{{requestQueryString}}</ua:queryString>
+                            <ua:tenantId>{{defaultProjectId}}</ua:tenantId>
+                            <ua:responseMessage>{{responseMessage}}</ua:responseMessage>
+                            <ua:userName>{{userName}}</ua:userName>
+                            <ua:roles>{{#each roles}}{{#if @index}} {{/if}}{{.}}{{/each}}</ua:roles>
+                        </ua:auditData>
+                    </cadf:content>
+                </cadf:attachment>
+            </cadf:attachments>
+            <cadf:observer id="{{serviceCode}}-{{clusterId}}-{{nodeId}}" name="repose" typeURI="service/security">
+                <cadf:host address="{{nodeId}}" />
+            </cadf:observer>
+            <cadf:reason reasonCode="{{responseCode}}"
+                         reasonType="http://www.iana.org/assignments/http-status-codes/http-status-codes.xml"/>
+        </cadf:event>
+        ]]>
+    </template>
+    <filterOut>
+      <match field="roles" regex="Racker"/>
+    </filterOut>
+    <filterOut>
+      <match field="roles" regex="cloudfeeds:service-admin"/>
+    </filterOut>
+    <filterOut>
+      <match field="roles" regex="cloudfeeds:cadf-publisher"/>
+    </filterOut>
+    <filterOut>
+      <match field="roles" regex="cloudfeeds:service-observer"/>
+    </filterOut>
+</highly-efficient-record-processor>

--- a/configuration/common/log4j2.xml
+++ b/configuration/common/log4j2.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration monitorInterval="30" packages="org.apache.logging.log4j.flume.appender">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout>
+                <Pattern>%d %-r4 [%t] %-5p %c - %m%n</Pattern>
+            </PatternLayout>
+        </Console>
+        <Flume name="EventLogger" compress="false">
+            <Agent host="localhost" port="10000"/>
+                <PatternLayout pattern="%m"/>
+        </Flume>
+        <RollingFile name="defaultFile"
+            filename="/var/log/repose/repose.log"
+            filePattern="/var/log/repose/repose.log.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-4r [%t] %-5p %c %x - %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="3"/>
+        </RollingFile>
+        <Syslog name="syslog" format="RFC5424"
+                host="syslog.staging.ord1.us.ci.rackspace.net"
+                port="514"
+                protocol="udp"
+                facility="local0"
+                appName="repose"
+                mdcId="mdc"
+                >
+            <LoggerFields>
+                <KeyValuePair key="thread" value="%t"/>
+                <KeyValuePair key="priority" value="%p"/>
+                <KeyValuePair key="category" value="%c"/>
+                <KeyValuePair key="level" value="%-5p"/>
+                <KeyValuePair key="ndc" value="%x"/>
+            </LoggerFields>
+        </Syslog>
+        <Syslog name="httpSyslog" format="RFC5424"
+                host="syslog.staging.ord1.us.ci.rackspace.net"
+                port="514"
+                protocol="udp"
+                facility="local1"
+                appName=""
+                mdcId="mdc"
+                >
+        </Syslog>
+        <RollingFile name="httpLocal"
+            filename="/var/log/repose/http_repose.log"
+            filePattern="/var/log/repose/http_repose.log.%i">
+            <PatternLayout>
+                <Pattern>%m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="3"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="WARN">
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="defaultFile"/>
+        </Root>
+        <Logger name="com.sun.jersey" level="off"/>
+        <Logger name="net.sf.ehcache" level="error"/>
+        <Logger name="org.apache.commons.httpclient" level="warn"/>
+        <Logger name="org.eclipse.jetty" level="off"/>
+        <Logger name="org.openrepose" level="info"/>
+        <Logger name="org.rackspace.deproxy" level="info"/>
+        <Logger name="org.springframework" level="warn"/>
+        <Logger name="intrafilter-logging" level="info"/>
+        <Logger name="http" level="info" additivity="false">
+            <AppenderRef ref="httpSyslog"/>
+            <AppenderRef ref="httpLocal"/>
+        </Logger>
+        <Logger name="org.openrepose.herp.pre.filter" level="warn"/>
+        <Logger name="org.openrepose.herp.post.filter" level="info" additivity="false">
+            <AppenderRef ref="EventLogger"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/configuration/common/openstack-authorization.cfg.xml
+++ b/configuration/common/openstack-authorization.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/Client+Authorization+Filter -->
+<rackspace-authorization xmlns="http://docs.openrepose.org/repose/openstack-identity/auth-z/v1.0">
+    <authentication-server username="auth" password="admin_password" href="AUTH_ENDPOINT"/>
+    <service-endpoint href="ATOM_HOPPER_SERVICE_CATALOG_ENTRY"/>
+</rackspace-authorization>
+

--- a/configuration/common/openstack-identity-v3.cfg.xml
+++ b/configuration/common/openstack-identity-v3.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<openstack-identity-v3 xmlns="http://docs.openrepose.org/repose/openstack-identity-v3/v1.0"
+                       token-cache-timeout="300000"
+                       groups-cache-timeout="300000"
+                       cache-offset="10000">
+
+    <white-list>
+        <uri-pattern>/application\.wadl$</uri-pattern>
+    </white-list>
+
+    <openstack-identity-service username="admin_username" password="admin_password" uri="http://identity.example.com"/>
+</openstack-identity-v3>

--- a/configuration/common/pass.wadl
+++ b/configuration/common/pass.wadl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<application
+        xmlns="http://wadl.dev.java.net/2009/02"
+        >
+
+    <grammars>
+    </grammars>
+    <resources base="http://localhost:8080/">
+        <resource path="resource">
+            <method name="GET" id="getContainer">
+            </method>
+        </resource>
+    </resources>
+</application>

--- a/configuration/common/pre-ratelimit-httplog.cfg.xml
+++ b/configuration/common/pre-ratelimit-httplog.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/HTTP+Logging+Filter -->
+<http-logging xmlns="http://docs.rackspacecloud.com/repose/http-logging/v1.0">
+    <!-- The id attribute is to help the user easily identify the log -->
+    <!-- The format includes what will be logged.  The arguments with % are a subset of the apache mod_log_config
+         found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
+
+    <http-log id="pre-ratelimit-log" format="{&quot;timestamp&quot;: &quot;%t&quot;, &quot;response_time_in_seconds&quot;: %T, &quot;response_code_modifiers&quot;: &quot;%200,201U&quot;, &quot;modifier_negation&quot;: &quot;%!401a&quot;, &quot;remote_ip&quot;: &quot;%a&quot;, &quot;local_ip&quot;: &quot;%A&quot;, &quot;response_size_in_bytes&quot;: &quot;%b&quot;, &quot;remote_host&quot;: &quot;%h&quot;, &quot;forwarded_for&quot;: &quot;%{x-forwarded-for}i&quot;, &quot;request_method&quot;: &quot;%m&quot;, &quot;server_port&quot;: %p, &quot;query_string&quot;: &quot;%q&quot;, &quot;status_code&quot;: %s, &quot;remote_user&quot;: &quot;%u&quot;, &quot;url_path_requested&quot;: &quot;%U&quot;}">
+        <targets><file location="/var/log/repose/pre-ratelimit-http.log"/></targets>
+    </http-log>
+
+</http-logging>
+

--- a/configuration/common/rackspace-identity-basic-auth.cfg.xml
+++ b/configuration/common/rackspace-identity-basic-auth.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rackspace-identity-basic-auth
+    xmlns="http://docs.openrepose.org/repose/rackspace-identity-basic-auth/v1.0"
+    rackspace-identity-service-uri="https://staging.identity-internal.api.rackspacecloud.com/v2.0/tokens"
+    token-cache-timeout-millis="600000">
+    <delegating quality="1.0"/>
+</rackspace-identity-basic-auth>

--- a/configuration/common/rate-limiting.cfg.xml
+++ b/configuration/common/rate-limiting.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->
+<rate-limiting  overLimit-429-responseCode="true" 
+    use-capture-groups="true"
+    xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+    <!--
+        Defines an endpoint with a matching regex to bind GET requests for
+        returning live rate limiting information.
+    -->
+    <request-endpoint uri-regex="/limits/?" include-absolute-limits="false"/>
+    <!-- Limits for all other requests -->
+
+    <limit-group id="limited" groups="IP_Standard" default="true">
+
+        <limit id="ip-default-POST" uri="/.*" uri-regex="/(.*)/events.*" http-methods="POST" unit="SECOND" value="310" />
+    </limit-group>
+
+    <limit-group id="unlimited" groups="IP_Super" default="false">
+    </limit-group>
+</rate-limiting>

--- a/configuration/common/responses-translation.cfg.xml
+++ b/configuration/common/responses-translation.cfg.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://wiki.openrepose.org/display/REPOSE/Translation -->
+<translation xmlns="http://docs.rackspacecloud.com/repose/translation/v1.0"
+    xsl-engine="SaxonEE" >
+    <request-translations>
+
+    </request-translations>
+    <response-translations>
+  
+        <response-translation 
+            code-regex="20[01]"
+            content-type="application/atom+xml" 
+            accept="*/*"
+            translated-content-type="*/*">
+            <style-sheets>
+    
+                <style id="filterPrivateAttrs" href="usage-schema/wadl/filter_private_attrs.xsl" />
+    
+            </style-sheets>
+        </response-translation>
+  
+    </response-translations>
+
+</translation>

--- a/configuration/common/slf4j-http-logging.cfg.xml
+++ b/configuration/common/slf4j-http-logging.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://repose.atlassian.net/wiki/display/REPOSE/SLF4J+HTTP+Logging+Filter -->
+<slf4j-http-logging xmlns="http://docs.openrepose.org/repose/slf4j-http-logging/v1.0">
+    <!-- The id attribute is to help the user easily identify the log 
+         it can then be used in log4j backend to determin which appender to go to -->
+    <!-- The format includes what will be logged.  The arguments with % are a subset of the apache mod_log_config
+         found at http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats -->
+
+    <slf4j-http-log 
+            id="http" 
+            format="{&quot;timestamp&quot;: &quot;%t&quot;, &quot;response_time_in_seconds&quot;: %T, &quot;response_code_modifiers&quot;: &quot;%200,201U&quot;, &quot;modifier_negation&quot;: &quot;%!401a&quot;, &quot;remote_ip&quot;: &quot;%a&quot;, &quot;local_ip&quot;: &quot;%A&quot;, &quot;response_size_in_bytes&quot;: &quot;%b&quot;, &quot;remote_host&quot;: &quot;%h&quot;, &quot;forwarded_for&quot;: &quot;%{x-forwarded-for}i&quot;, &quot;request_method&quot;: &quot;%m&quot;, &quot;server_port&quot;: %p, &quot;query_string&quot;: &quot;%q&quot;, &quot;status_code&quot;: %s, &quot;remote_user&quot;: &quot;%u&quot;, &quot;user_id&quot;: &quot;%{x-user-id}i&quot;, &quot;username&quot;: &quot;%{x-user-name}i&quot;, &quot;tenant_id&quot;: &quot;%{x-tenant-id}i&quot;, &quot;url_path_requested&quot;: &quot;%U&quot;, &quot;accept&quot;: &quot;%{accept}i&quot;}" />
+
+</slf4j-http-logging>
+

--- a/configuration/common/system-model.cfg.xml
+++ b/configuration/common/system-model.cfg.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+    <nodes>
+       <!-- <node id="repose_atom-app-n01" hostname="atom-app-n01.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n02" hostname="atom-app-n02.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n03" hostname="atom-app-n03.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n04" hostname="atom-app-n04.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n05" hostname="atom-app-n05.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n06" hostname="atom-app-n06.test.ord1.ci.rackspace.net" http-port="9090"/>-->
+      <node id="repose_node1" hostname="localhost" http-port="9090"/>
+    </nodes>
+    <filters>
+      <filter name="slf4j-http-logging" />
+      <filter name="uri-normalization" />
+      <filter name="header-normalization" />
+<!--  <filter name="ip-identity" /> -->  
+<!--  <filter name="rate-limiting" /> -->
+<!--  <filter configuration="rackspace-identity-basic-auth.cfg.xml" name="rackspace-identity-basic-auth" /> -->
+<!--  <filter name="client-auth" uri-regex="(/.+/events/?|/.+/events/?[?].+|/.+/events/entries.*|/feedscatalog\/catalog/?)" /> -->
+<!--  <filter configuration="tenantid-client-auth-n.cfg.xml" name="client-auth" uri-regex="(/.+/events/[^/?]+(/entries/[^?]+)?/?(\?.*)?|/feedscatalog\/catalog\/[^/?]+/?)" />-->      
+<!--  <filter configuration="header-translation.cfg.xml" name="header-translation" /> -->
+<!--  <filter configuration="user-rate-limiting.cfg.xml" name="rate-limiting" /> -->
+<!--  <filter name="json-xml-filter" />  -->      
+      <filter name="api-validator" />
+      <filter name="herp" uri-regex=".+/events/.*" />
+      <filter name="derp" />
+      <filter configuration="header-normalization-karate.cfg.xml" name="header-normalization" />
+    </filters>
+
+    <services>
+    <!--  <service name="dist-datastore" />-->
+    </services>
+    <destinations>
+      <endpoint default="true" hostname="localhost" id="atomhopper_localhost" port="8080" protocol="http" root-path="" />
+    </destinations>
+</system-model>
+

--- a/configuration/common/tenantid-translation.cfg.xml
+++ b/configuration/common/tenantid-translation.cfg.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://wiki.openrepose.org/display/REPOSE/Translation -->
+<translation xmlns="http://docs.rackspacecloud.com/repose/translation/v1.0"
+    xsl-engine="SaxonEE" >
+    <request-translations>
+  
+        <request-translation 
+            http-methods="" 
+            content-type="*/*" 
+            accept="application/atom+xml"
+            translated-content-type="application/atom+xml">
+            <style-sheets>
+    
+                <style id="tenantid" href="usage-schema/wadl/tenant-feed.xsl" />
+    
+            </style-sheets>
+        </request-translation>
+  
+
+    </request-translations>
+
+</translation>

--- a/configuration/common/uri-identity.cfg.xml
+++ b/configuration/common/uri-identity.cfg.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/URI+Identity -->
+<uri-identity xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+              xmlns='http://docs.openrepose.org/repose/uri-identity/v1.0'
+              xsi:schemaLocation='http://docs.openrepose.org/repose/uri-identity/v1.0 ../config/uri-identity-configuration.xsd'>
+
+    <identification-mappings>
+        <mapping identification-regex=".*/servers/(\w*)/.*"/>
+        <mapping identification-regex=".*/servers/(\w*)/.*"/>
+    </identification-mappings>
+
+    <group>User_Standard</group>
+    <quality>0.5</quality>
+
+</uri-identity>

--- a/configuration/common/uri-normalization.cfg.xml
+++ b/configuration/common/uri-normalization.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uri-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://docs.openrepose.org/repose/uri-normalization/v1.0"
+    xsi:schemaLocation="http://docs.openrepose.org/repose/uri-normalization/v1.0">
+    <media-variants>
+        <media-type name="application/xml" variant-extension="xml" />
+        <media-type name="application/atom+xml" preferred="true" variant-extension="atom" />
+        <media-type name="application/atomsvc+xml" variant-extension="xml" />
+        <media-type name="application/json" variant-extension="json" />
+        <media-type name="application/vnd.rackspace.atom+json" variant-extension="json" />
+        <media-type name="application/vnd.rackspace.atomsvc+json" variant-extension="json" />
+    </media-variants>
+</uri-normalization>

--- a/configuration/common/user-rate-limiting.cfg.xml
+++ b/configuration/common/user-rate-limiting.cfg.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->
+<rate-limiting  overLimit-429-responseCode="true" 
+    use-capture-groups="true"
+    xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+    <!--
+        Defines an endpoint with a matching regex to bind GET requests for
+        returning live rate limiting information.
+    -->
+    <request-endpoint uri-regex="/limits/users/?" include-absolute-limits="false"/>
+    <!-- Limits for all other requests -->
+
+    <limit-group id="UserRole_Group" groups="cloudfeeds:observer" default="true">
+
+        <limit id="observer-user-GET" uri="^/(?!.*test).*/events.*" uri-regex="^/(?!.*test)(.*)/events.*" http-methods="GET" unit="MINUTE" value="10" />
+    </limit-group>
+
+    <limit-group id="UserIdentity_Group" groups="UserIdentity_Group cloudfeeds:service-admin cloudfeeds:service-observer cloudfeeds:cadf-publisher" default="false">
+
+        <limit id="sites-POST" uri="/sites/events.*" uri-regex="/(sites)/events.*" http-methods="POST" unit="SECOND" value="675" />
+
+        <limit id="files-POST" uri="/files/events.*" uri-regex="/(files)/events.*" http-methods="POST" unit="SECOND" value="300" />
+
+        <limit id="service-admin-user-POST" uri="^/(?!.*test|sites|files).*/events.*" uri-regex="^/(?!.*test|sites|files)(.*)/events.*" http-methods="POST" unit="SECOND" value="200" />
+
+        <limit id="service-admin-user-GET" uri="^/(?!.*test).*/events.*" uri-regex="^/(?!.*test)(.*)/events.*" http-methods="GET" unit="SECOND" value="350" />
+    </limit-group>
+</rate-limiting>

--- a/configuration/common/validator.cfg.xml
+++ b/configuration/common/validator.cfg.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<validators
+    multi-role-match="true"
+    xmlns="http://docs.openrepose.org/repose/validator/v1.0">
+    <delegating quality="0.7"/>
+    <validator 
+        role="default" 
+        default="true"
+        wadl="usage-schema/allfeeds.wadl"
+        dot-output="/var/repose/allfeeds.dot"
+        check-well-formed="true"
+        check-xsd-grammar="true"
+        check-elements="true"
+        check-plain-params="true"
+        do-xsd-grammar-transform="true"
+        enable-pre-process-extension="true"
+        remove-dups="true"
+        xpath-version="2"
+        xsl-engine="XalanC"
+        xsd-engine="SaxonEE"
+        join-xpath-checks="true"
+        check-headers="true"
+        enable-rax-roles="true"
+    >
+    </validator>
+</validators>

--- a/configuration/common/versioning.cfg.xml
+++ b/configuration/common/versioning.cfg.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/Versioning+Filter -->
+<versioning xmlns="http://docs.openrepose.org/repose/versioning/v2.0">
+    <service-root href="http://localhost:8080/"/>
+
+    <version-mapping id="v1" pp-dest-id="service-v1" status="DEPRECATED">
+        <media-types>
+            <media-type base="application/xml" type="application/vnd.vendor.service-v1+xml"/>
+            <media-type base="application/json" type="application/vnd.vendor.service-v1+json"/>
+            <media-type base="application/xml" type="application/vnd.vendor.service+xml; version=1"/>
+            <media-type base="application/json" type="application/vnd.vendor.service+json; version=1"/>
+            <media-type base="application/xml" type="application/v1+xml"/>
+            <media-type base="application/json" type="application/v1+json"/>
+            <media-type base="application/xml" type="application/vnd.rackspace; x=v1; y=xml"/>
+            <media-type base="application/json" type="application/vnd.rackspace; x=v1; y=json"/>
+            <media-type base="application/json" type="application/vnd.rackspace; rnd=1; x=v1; rnd2=2; y=xml"/>
+            <media-type base="application/json" type="application/vnd.rackspace; rnd=1; x=v1; rnd2=2; y=json"/>
+        </media-types>
+    </version-mapping>
+
+    <version-mapping id="v2" pp-dest-id="service-v2" status="CURRENT">
+        <media-types>
+            <media-type base="application/xml" type="application/vnd.vendor.service-v2+xml"/>
+            <media-type base="application/json" type="application/vnd.vendor.service-v2+json"/>
+            <media-type base="application/xml" type="application/vnd.vendor.service+xml; version=2"/>
+            <media-type base="application/json" type="application/vnd.vendor.service+json; version=2"/>
+            <media-type base="application/xml" type="application/v2+xml"/>
+            <media-type base="application/json" type="application/v2+json"/>
+            <media-type base="application/xml" type="application/vnd.rackspace; x=v2; y=xml"/>
+            <media-type base="application/json" type="application/vnd.rackspace; x=v2; y=json"/>
+            <media-type base="application/json" type="application/vnd.rackspace; rnd=1; x=v2; rnd2=2; y=xml"/>
+            <media-type base="application/json" type="application/vnd.rackspace; rnd=1; x=v2; rnd2=2; y=json"/>
+        </media-types>
+    </version-mapping>
+</versioning>

--- a/configuration/external/destination-router.cfg.xml
+++ b/configuration/external/destination-router.cfg.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<destination-router xmlns='http://docs.openrepose.org/repose/destination-router/v1.0'>
+  <target id="archive" quality="1"/>
+</destination-router>

--- a/configuration/external/dist-datastore.cfg.xml
+++ b/configuration/external/dist-datastore.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/Distributed+Datastore -->
+<distributed-datastore xmlns="http://docs.openrepose.org/repose/distributed-datastore/v1.0">
+   <allowed-hosts allow-all="false">
+      <allow host="127.0.0.1" />
+      <allow host="cloudfeeds-repose-n01.test.ord1.ci.rackspace.net" />
+      <allow host="cloudfeeds-repose-n02.test.ord1.ci.rackspace.net" />
+   </allowed-hosts>
+   <port-config>
+     <port port="9191" cluster="repose" />
+   </port-config>
+</distributed-datastore>
+

--- a/configuration/external/header-translation.cfg.xml
+++ b/configuration/external/header-translation.cfg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<header-translation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://docs.openrepose.org/repose/header-translation/v1.0 ../config/header-translation.xsd"
+    xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
+    <header original-name="x-roles" new-name="x-pp-groups" remove-original="false" />
+    <header original-name="Host" new-name="x-external-loc" remove-original="false" />
+
+</header-translation>

--- a/configuration/external/http-connection-pool.cfg.xml
+++ b/configuration/external/http-connection-pool.cfg.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+
+    <!-- Configuration for the default pool.  Any users of the service will by default, retrieve HTTP connections
+        using this default pool configuration.
+    -->
+    <pool id="default"
+        default="true"
+        http.conn-manager.max-total="500"
+        http.conn-manager.max-per-route="200"
+        http.socket.timeout="120000"
+        http.socket.buffer-size="16384"
+        http.connection.timeout="30000"
+        http.connection.max-line-length="8192"
+        http.connection.max-header-count="256"
+        http.connection.max-status-line-garbage="100"
+        http.tcp.nodelay="true"
+        keepalive.timeout="10000"/>
+
+
+
+    <pool id="client-auth-pool"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="50"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="16384"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/configuration/external/ip-identity.cfg.xml
+++ b/configuration/external/ip-identity.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ip-identity  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://docs.openrepose.org/repose/ip-identity/v1.0"
+    xsi:schemaLocation="http://docs.openrepose.org/repose/ip-identity/v1.0">
+    <quality>0.2</quality>
+    <white-list quality="0.3">
+
+        <ip-address>127.0.0.1</ip-address>
+
+        <ip-address>192.237.239.12</ip-address>
+    </white-list>
+
+</ip-identity>

--- a/configuration/external/system-model.cfg.xml
+++ b/configuration/external/system-model.cfg.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+  <repose-cluster id="repose">
+    <nodes>
+        <node id="repose_cloudfeeds-repose-n01" hostname="cloudfeeds-repose-n01.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_cloudfeeds-repose-n02" hostname="cloudfeeds-repose-n02.test.ord1.ci.rackspace.net" http-port="9090"/>
+    </nodes>
+    <filters>
+      <filter name="slf4j-http-logging" />
+      <filter name="uri-normalization" uri-regex="^(?!/archive/).*" />
+      <filter configuration="uri-normalization-archive.cfg.xml" name="uri-normalization" uri-regex="^/archive/.*" />
+      <filter name="header-normalization" />
+      <filter name="ip-identity" />
+      <filter name="rate-limiting" />
+      <filter name="rackspace-identity-basic-auth" />
+      <filter name="client-auth" uri-regex="(/.+/events/?|/.+/events/?[?].+|/.+/events/entries.*|/feedscatalog\/catalog/?)" />
+      <filter configuration="tenantid-client-auth-n.cfg.xml" name="client-auth" uri-regex="(/.+/events/[^/?]+(/entries/[^?]+)?/?(\?.*)?|/feedscatalog\/catalog\/[^/?]+/?|^/archive/.*)" />
+      <filter configuration="header-translation.cfg.xml" name="header-translation" />
+      <filter configuration="user-rate-limiting.cfg.xml" name="rate-limiting" uri-regex="^(?!/archive/).*" />
+      <filter configuration="user-archive-rate-limiting.cfg.xml" name="rate-limiting" uri-regex="^/archive/.*" />
+      <filter name="json-xml-filter" uri-regex="^(?!/archive/).*" />
+      <filter name="api-validator" uri-regex="^(?!/archive/).*" />
+      <filter configuration="validator-archive.cfg.xml" name="api-validator" uri-regex="^/archive/.*" />
+      <filter name="uri-stripper" uri-regex="^/archive/.*" />
+      <filter configuration="destination-router.cfg.xml" name="destination-router" uri-regex="^/archive/[^/?]+/[^/?]+/(iad|dfw|ord|lon|hkg|syd)_([^/?]+)_[1-9]\d{3}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\.(xml|json)" />
+      <filter name="herp" uri-regex="^(?!/archive/).+/events/.+" />
+      <filter name="derp" />
+      <filter configuration="header-normalization-karate.cfg.xml" name="header-normalization" />
+    </filters>
+
+    <services>
+      <service name="dist-datastore" />
+    </services>
+    <destinations>
+      <endpoint default="false" hostname="storage101.pprod1.clouddrive.com" id="archive" port="443" protocol="https" root-path="v1" />
+      <endpoint default="true" hostname="atomhopper.test.ord1.ci.rackspace.net" id="atom_vip" port="443" protocol="https" root-path="" />
+    </destinations>
+  </repose-cluster>
+</system-model>
+

--- a/configuration/external/tenantid-client-auth-n.cfg.xml
+++ b/configuration/external/tenantid-client-auth-n.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<client-auth xmlns="http://docs.openrepose.org/repose/client-auth/v1.0">
+
+    <delegating quality="0.8"/>
+    <openstack-auth  tenanted="true" group-cache-timeout="60000" connectionPoolId="client-auth-pool" token-cache-timeout="600000"  send-all-tenant-ids="true" xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+        <identity-service username="atomhopper" password="JZHW45davGruWApx" uri="https://staging.identity-internal.api.rackspacecloud.com/v2.0" />
+          <client-mapping id-regex="/.+/events/([^/?]+)(/entries/[^?]+)?/?(\?.*)?"/>
+        <client-mapping id-regex="/feedscatalog/catalog/([^/?]+)/?"/>
+        <client-mapping id-regex="/archive/([^/?]+)/.*"/>
+    </openstack-auth>
+
+
+</client-auth>

--- a/configuration/external/uri-normalization-archive.cfg.xml
+++ b/configuration/external/uri-normalization-archive.cfg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uri-normalization xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://docs.openrepose.org/repose/uri-normalization/v1.0"
+    xsi:schemaLocation="http://docs.openrepose.org/repose/uri-normalization/v1.0">
+    <media-variants>
+    </media-variants>
+</uri-normalization>

--- a/configuration/external/uri-stripper.cfg.xml
+++ b/configuration/external/uri-stripper.cfg.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uri-stripper xmlns="http://docs.openrepose.org/repose/uri-stripper/v1.0" rewrite-location="true" token-index="0"/>

--- a/configuration/external/user-archive-rate-limiting.cfg.xml
+++ b/configuration/external/user-archive-rate-limiting.cfg.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://wiki.openrepose.org/display/REPOSE/Rate+Limiting+Filter -->
+<rate-limiting  overLimit-429-responseCode="true" 
+    use-capture-groups="true"
+    xmlns="http://docs.openrepose.org/repose/rate-limiting/v1.0">
+    <!--
+        Defines an endpoint with a matching regex to bind GET requests for
+        returning live rate limiting information.
+    -->
+    <request-endpoint uri-regex="/limits/users/?" include-absolute-limits="false"/>
+    <!-- Limits for all other requests -->
+
+    <limit-group id="UserRole_Group" groups="cloudfeeds:observer" default="true">
+
+        <limit id="observer-user-GET" uri="^/archive/([^/?]+)/.*" uri-regex="^/archive/([^/?]+)/.*" http-methods="GET" unit="MINUTE" value="10" />
+    </limit-group>
+
+    <limit-group id="UserIdentity_Group" groups="UserIdentity_Group cloudfeeds:service-admin" default="false">
+
+        <limit id="service-admin-user-GET" uri="^/archive/([^/?]+)/.*" uri-regex="^/archive/([^/?]+)/.*" http-methods="GET" unit="SECOND" value="350" />
+    </limit-group>
+</rate-limiting>

--- a/configuration/external/validator-archive.cfg.xml
+++ b/configuration/external/validator-archive.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<validators
+    multi-role-match="true"
+    xmlns="http://docs.openrepose.org/repose/validator/v1.0">
+    <validator 
+        role="default" 
+        default="true"
+        wadl="usage-schema/archive.wadl"
+        dot-output="/var/repose/archive.dot"
+        enable-rax-roles="true"
+    >
+    </validator>
+</validators>

--- a/configuration/internal/compression.cfg.xml
+++ b/configuration/internal/compression.cfg.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<content-compression xmlns="http://docs.api.rackspacecloud.com/repose/content-compression/v1.0">
+    <compression compression-threshold="1024" debug="true" include-content-types="application/atom+xml" />
+</content-compression>

--- a/configuration/internal/destination-router.cfg.xml
+++ b/configuration/internal/destination-router.cfg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/pages/viewpage.action?pageId=328596 -->
+<destination-router xmlns='http://docs.openrepose.org/repose/destination-router/v1.0'>
+    <target id="openrepose" quality="0.5"/>
+</destination-router>

--- a/configuration/internal/dist-datastore.cfg.xml
+++ b/configuration/internal/dist-datastore.cfg.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://wiki.openrepose.org/display/REPOSE/Distributed+Datastore -->
+<distributed-datastore xmlns="http://docs.openrepose.org/repose/distributed-datastore/v1.0">
+   <allowed-hosts allow-all="false">
+      <allow host="127.0.0.1" />
+      <allow host="atom-app-n01.test.ord1.ci.rackspace.net" />
+      <allow host="atom-app-n02.test.ord1.ci.rackspace.net" />
+      <allow host="atom-app-n03.test.ord1.ci.rackspace.net" />
+      <allow host="atom-app-n04.test.ord1.ci.rackspace.net" />
+      <allow host="atom-app-n05.test.ord1.ci.rackspace.net" />
+      <allow host="atom-app-n06.test.ord1.ci.rackspace.net" />
+   </allowed-hosts>
+   <port-config>
+     <port port="9191" cluster="repose" />
+   </port-config>
+</distributed-datastore>
+

--- a/configuration/internal/header-translation.cfg.xml
+++ b/configuration/internal/header-translation.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<header-translation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://docs.openrepose.org/repose/header-translation/v1.0 ../config/header-translation.xsd"
+    xmlns="http://docs.openrepose.org/repose/header-translation/v1.0">
+    <header original-name="x-roles" new-name="x-pp-groups" remove-original="false" />
+
+</header-translation>

--- a/configuration/internal/http-connection-pool.cfg.xml
+++ b/configuration/internal/http-connection-pool.cfg.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<http-connection-pools xmlns="http://docs.openrepose.org/repose/http-connection-pool/v1.0">
+
+    <!-- Configuration for the default pool.  Any users of the service will by default, retrieve HTTP connections
+        using this default pool configuration.
+    -->
+    <pool id="default"
+        default="true"
+        http.conn-manager.max-total="200"
+        http.conn-manager.max-per-route="50"
+        http.socket.timeout="120000"
+        http.socket.buffer-size="16384"
+        http.connection.timeout="30000"
+        http.connection.max-line-length="8192"
+        http.connection.max-header-count="256"
+        http.connection.max-status-line-garbage="100"
+        http.tcp.nodelay="true"
+        keepalive.timeout="10000"/>
+
+
+
+    <pool id="client-auth-pool"
+          default="false"
+          http.conn-manager.max-total="200"
+          http.conn-manager.max-per-route="50"
+          http.socket.timeout="30000"
+          http.socket.buffer-size="16384"
+          http.connection.timeout="30000"
+          http.connection.max-line-length="8192"
+          http.connection.max-header-count="100"
+          http.connection.max-status-line-garbage="100"
+          http.tcp.nodelay="true"
+          keepalive.timeout="0"/>
+</http-connection-pools>

--- a/configuration/internal/ip-identity.cfg.xml
+++ b/configuration/internal/ip-identity.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ip-identity  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://docs.openrepose.org/repose/ip-identity/v1.0"
+    xsi:schemaLocation="http://docs.openrepose.org/repose/ip-identity/v1.0">
+    <quality>0.2</quality>
+    <white-list quality="0.3">
+
+        <ip-address>127.0.0.1</ip-address>
+
+        <ip-address>10.x.x.x</ip-address>
+
+    </white-list>
+
+</ip-identity>

--- a/configuration/internal/system-model.cfg.xml
+++ b/configuration/internal/system-model.cfg.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
+<system-model xmlns="http://docs.openrepose.org/repose/system-model/v2.0">
+  <repose-cluster id="repose">
+    <nodes>
+        <node id="repose_atom-app-n01" hostname="atom-app-n01.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n02" hostname="atom-app-n02.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n03" hostname="atom-app-n03.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n04" hostname="atom-app-n04.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n05" hostname="atom-app-n05.test.ord1.ci.rackspace.net" http-port="9090"/>
+        <node id="repose_atom-app-n06" hostname="atom-app-n06.test.ord1.ci.rackspace.net" http-port="9090"/>
+    </nodes>
+    <filters>
+      <filter name="slf4j-http-logging" />
+      <filter name="uri-normalization" />
+      <filter name="header-normalization" />
+      <filter name="ip-identity" />
+      <filter name="rate-limiting" />
+      <filter configuration="rackspace-identity-basic-auth.cfg.xml" name="rackspace-identity-basic-auth" />
+      <filter name="client-auth" uri-regex="(/.+/events/?|/.+/events/?[?].+|/.+/events/entries.*|/feedscatalog\/catalog/?)" />
+      <filter configuration="tenantid-client-auth-n.cfg.xml" name="client-auth" uri-regex="(/.+/events/[^/?]+(/entries/[^?]+)?/?(\?.*)?|/feedscatalog\/catalog\/[^/?]+/?)" />
+      <filter configuration="header-translation.cfg.xml" name="header-translation" />
+      <filter configuration="user-rate-limiting.cfg.xml" name="rate-limiting" />
+      <filter name="json-xml-filter" />
+      <filter name="api-validator" />
+      <filter name="herp" uri-regex=".+/events/.*" />
+      <filter name="derp" />
+      <filter configuration="header-normalization-karate.cfg.xml" name="header-normalization" />
+    </filters>
+
+    <services>
+      <service name="dist-datastore" />
+    </services>
+    <destinations>
+      <endpoint default="true" hostname="localhost" id="atomhopper_localhost" port="8080" protocol="http" root-path="" />
+    </destinations>
+  </repose-cluster>
+</system-model>
+

--- a/configuration/internal/tenantid-client-auth-n.cfg.xml
+++ b/configuration/internal/tenantid-client-auth-n.cfg.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<client-auth xmlns="http://docs.openrepose.org/repose/client-auth/v1.0">
+
+    <delegating quality="0.8"/>
+    <openstack-auth  tenanted="true" group-cache-timeout="60000" connectionPoolId="client-auth-pool" token-cache-timeout="600000"  send-all-tenant-ids="true" xmlns="http://docs.openrepose.org/repose/client-auth/os-ids-auth/v1.0">
+        <identity-service username="atomhopper" password="JZHW45davGruWApx" uri="https://staging.identity-internal.api.rackspacecloud.com/v2.0" />
+          <client-mapping id-regex="/.+/events/([^/?]+)(/entries/[^?]+)?/?(\?.*)?"/>
+        <client-mapping id-regex="/feedscatalog/catalog/([^/?]+)/?"/>
+    </openstack-auth>
+
+
+</client-auth>

--- a/configuration/internal/uri-stripper.cfg.xml
+++ b/configuration/internal/uri-stripper.cfg.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uri-stripper xmlns="http://docs.openrepose.org/repose/uri-stripper/v1.0" rewrite-location="true" token-index="1"/>

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,38 @@
+#As repose image exposes /etc/repose as volume hence adding any artifact by wget of curl are getting removed,
+#only way is to COPY or ADD, hance creating a multistage Dockerfile to curl and add the schema package
+
+FROM alpine:3.13 as schema
+
+#UsageSchema version
+ARG schema_version
+ENV SCHEMA_VERSION=${schema_version}
+RUN apk --no-cache add curl tar \
+    && curl https://maven.research.rackspacecloud.com/content/repositories/releases/com/rackspace/usage/usage-schema/${SCHEMA_VERSION}/usage-schema-${SCHEMA_VERSION}-schema.tar.gz ${APP_ROOT} | tar xz 
+
+
+FROM repose-docker-local.artifacts.rackspace.net/ubuntu/reposeimage:latest
+
+USER root
+
+ARG saxon_lic
+
+ENV SAXON_HOME=/etc/saxon \
+    http_proxy= \
+    APP_ROOT=/etc/repose \
+    JAVA_OPTS="-Dcom.sun.management.jmxremote.port=1299 -Dcom.sun.management.jmxremote.password.file=/etc/repose/jmxremote.password -Dcom.sun.management.jmxremote.access.file=/etc/repose/jmxremote.access -Dcom.sun.management.jmxremote.ssl=false -Xms2048m -Xmx2048m" 
+
+RUN mkdir -p ${SAXON_HOME} /var/log/repose/
+#Inherited from Repose image
+WORKDIR ${APP_ROOT}
+#Remove existing configuration
+RUN rm -r ${APP_ROOT}/*
+
+COPY ./configuration/common ./files/jmx/ ${APP_ROOT}/
+COPY ./files/saxon.sh ./files/saxon.csh /etc/profile.d/
+COPY ./files/repose-logrotate /etc/logrotate.d/repose
+COPY ${saxon_lic} ${SAXON_HOME}/saxon-license.lic
+COPY --from=schema /usage-schema* ${APP_ROOT}/usage-schema
+
+EXPOSE 9090 
+# Start Repose.
+CMD java $JAVA_OPTS -jar /usr/share/repose/repose.jar -c /etc/repose && tail -f /var/log/repose/repose.log

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,36 @@
+# docker build image and run the conatiner
+**This docuemntation is in progress and subjected to change with the addition of new configuration files**
+Your current direcotry should be pointing to ***cloudfeeds-repose-filters*** 
+
+>Setup Jfrog repository login for pulling Repose docker image.
+$docker login https://repose-docker-local.artifacts.rackspace.net
+>Enter your credentials
+
+Passing value of the **schema_version** argument is mandatory for successful build. This defines version for *usage-schema*
+Run the following command to build an image by providing the *schema_version* value. 
+```
+$docker build --build-arg schema_version=[schema_version] -f docker/Dockerfile -t repose-valve:9.1.0.0 . 
+```
+Use the following command to run a repose-valve container on port 9090
+```
+$docker run -itd --name [Conatiner_Name] -p 9090:9090 repose-valve:9.1.0.0
+```
+
+Test with *curl -v http://localhost:9090*
+
+Following environment variables are set 
+```
+SAXON_HOME=/etc/saxon
+APP_ROOT=/etc/repose
+APP_VARS=/var/repose
+APP_LOGS=/var/log/repose
+```
+
+Example of building an image with schema version 1.137.0  and running a container.
+```
+$docker build --build-arg schema_version=1.137.0 -t repose-valve:9.1.0.0 .
+$docker run -itd --name repose-valve -p 9090:9090 repose-valve:9.1.0.0
+```
+
+
+

--- a/files/jmx/jmxremote.access
+++ b/files/jmx/jmxremote.access
@@ -1,0 +1,1 @@
+authsvc readonly

--- a/files/jmx/jmxremote.password
+++ b/files/jmx/jmxremote.password
@@ -1,0 +1,1 @@
+authsvc XcyZ2qNA

--- a/files/repose-logrotate
+++ b/files/repose-logrotate
@@ -1,0 +1,13 @@
+/var/log/repose/current.log /var/log/repose/stdout.log /var/log/repose/stderr.log
+ {
+    rotate 7
+    daily
+    missingok
+    compress
+    copytruncate
+    dateext
+    postrotate
+      # cleanup old repose.log.YYYY-mm-dd files
+      find /var/log/repose \( -name "repose.log.20*" -o -name "credentials*" -o -name "pre-ratelimit-http*" \) -mtime +7 -type -delete
+    enscript
+}

--- a/files/saxon.csh
+++ b/files/saxon.csh
@@ -1,0 +1,1 @@
+setenv SAXON_HOME /etc/saxon

--- a/files/saxon.sh
+++ b/files/saxon.sh
@@ -1,0 +1,1 @@
+export SAXON_HOME=/etc/saxon


### PR DESCRIPTION
The initial commit contains the following changes:

- Common, Internal, and External filter configuration files extracted from test node to be configured in a docker container
- Dockerfile contains common configuration to both Internal and external repose valve
- Copied required files from [cloudfeeds-puppet](https://github.rackspace.com/atom-hopper-team/puppet-cloudfeeds/tree/master/files) because this repository will serve as the repository for cloud feeds repose valve container going forward
- Also created a feature branch to merge all the container changes in a single place.
- Dependent on the artifact release by https://github.com/rackerlabs/standard-usage-schemas/pull/732